### PR TITLE
[FIX] account.asset.profile

### DIFF
--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -55,9 +55,8 @@ class AccountAssetProfile(models.Model):
     name = fields.Char('Name', size=64, required=True, index=1)
     note = fields.Text('Note')
     account_analytic_id = fields.Many2one(
-        'account.analytic.account', 'Analytic account',
-        domain=[('type', '!=', 'view'),
-                ('state', 'not in', ('close', 'cancelled'))])
+        'account.analytic.account', 'Analytic account'
+        )
     account_asset_id = fields.Many2one(
         'account.account', 'Asset Account', required=True)
     account_depreciation_id = fields.Many2one(


### PR DESCRIPTION
this fixes a stack trace on the account_asset_profile form view when trying to set an analytic account (the domain was using fields not present on account.analytic.account in v10)