### PR TITLE
[12.0] Improve your OCA PR (includes one important fix)

### DIFF
--- a/account_check_deposit/models/res_company.py
+++ b/account_check_deposit/models/res_company.py
@@ -5,7 +5,7 @@
 # @author: Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields
+from odoo import fields, models
 
 
 class ResCompany(models.Model):
@@ -19,3 +19,5 @@ class ResCompany(models.Model):
         'account.account', string='Transfer Account for Check Deposits',
         ondelete='restrict', copy=False,
         domain=[('reconcile', '=', True), ('deprecated', '=', False)])
+    check_deposit_post_move = fields.Boolean(
+        string='Post Move for Check Deposits')

--- a/account_check_deposit/models/res_config_settings.py
+++ b/account_check_deposit/models/res_config_settings.py
@@ -16,3 +16,6 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.check_deposit_transfer_account_id',
         readonly=False,
     )
+    check_deposit_post_move = fields.Boolean(
+        related='company_id.check_deposit_post_move', readonly=False,
+    )

--- a/account_check_deposit/readme/USAGE.rst
+++ b/account_check_deposit/readme/USAGE.rst
@@ -1,10 +1,10 @@
 When you receive a check that pays a customer invoice, you can go to that
 invoice and click on the button *Register Payment* and select the
-*Check Received* journal as *Payment Method*.
+*Check Received* journal as *Payment Journal*.
 
 When you want to deposit checks to the bank, go to the menu
-*Accounting > Adviser > Check Deposit*, create a new check deposit and set the
+*Invoicing > Accounting > Check Deposit*, create a new check deposit and set the
 journal *Checks Received* and select the bank account on which you want to
-credit the checks. Then click on *Add an item* to select the checks you want to
+credit the checks. Then click on *Add a line* to select the checks you want to
 deposit at the bank. Eventually, validate the deposit and print the report
 (you probably want to customize this report).

--- a/account_check_deposit/report/report.xml
+++ b/account_check_deposit/report/report.xml
@@ -14,6 +14,7 @@
             report_type="qweb-pdf"
             name="account_check_deposit.report_checkdeposit"
             file="account_check_deposit.report_checkdeposit"
+            print_report_name="'check_deposit-%s%s' % (object.name, object.state == 'draft' and '-draft' or '')"
     />
 
 </odoo>

--- a/account_check_deposit/security/check_deposit_security.xml
+++ b/account_check_deposit/security/check_deposit_security.xml
@@ -11,7 +11,6 @@
     <record id="check_deposit_rule" model="ir.rule">
         <field name="name">Check Deposit multi-company</field>
         <field name="model_id" ref="model_account_check_deposit"/>
-        <field name="global" eval="True"/>
         <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
     </record>
 

--- a/account_check_deposit/tests/__init__.py
+++ b/account_check_deposit/tests/__init__.py
@@ -1,2 +1,1 @@
-
 from . import test_check_deposit

--- a/account_check_deposit/views/account_deposit_view.xml
+++ b/account_check_deposit/views/account_deposit_view.xml
@@ -22,6 +22,7 @@
                             states="done"
                             string="Back to Draft"
                             type="object"/>
+                    <button name="get_report" string="Print" type="object"/>
                     <field name="state"
                            widget="statusbar"
                            statusbar_visible="draft,done"/>

--- a/account_check_deposit/views/res_config_settings_views.xml
+++ b/account_check_deposit/views/res_config_settings_views.xml
@@ -23,13 +23,21 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-xs-12 col-md-6 o_setting_box" attrs="{'invisible': ['|', ('has_chart_of_accounts', '=', False), ('check_deposit_offsetting_account', '!=', 'transfer_account')]}">
+                    <div class="col-xs-12 col-md-6 o_setting_box" attrs="{'invisible': ['|', ('has_chart_of_accounts', '=', False), ('check_deposit_offsetting_account', '!=', 'transfer_account')]}" id="account_check_deposit_transfer_account_id">
                         <div class="o_setting_left_pane"/>
                         <div class="o_setting_right_pane">
                             <label for="check_deposit_transfer_account_id"/>
                             <field name="check_deposit_transfer_account_id" class="oe_inline"
                                    context="{'default_reconcile': True}"
                             />
+                        </div>
+                    </div>
+                    <div class="col-xs-12 col-md-6 o_setting_box" id="account_check_deposit_post_move">
+                        <div class="o_setting_left_pane">
+                            <field name="check_deposit_post_move" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="check_deposit_post_move"/>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
account_check_deposit: Don't force 'name' of account.move (fix up-ported from v10)
Add print button (feature up-ported from v10)
Add option to post moves (feature up-ported from v10)
Sequence now takes into account the deposit date
Customize the filename of the report
Update README with v12 labels